### PR TITLE
Inserir quebras de linha nos comunicados

### DIFF
--- a/src/Pages/Comunicados/index.tsx
+++ b/src/Pages/Comunicados/index.tsx
@@ -135,7 +135,7 @@ export default function Comunicados() {
                                         </TextData>
                                     </CardData>
                                     
-                                    <CardMensagem><TextMensagem>{comentario.comunicado}</TextMensagem></CardMensagem>
+                                    <CardMensagem><TextMensagem dangerouslySetInnerHTML={{ __html: comentario.comunicado.replace(/\n/g, '<br>') }}></TextMensagem></CardMensagem>
                                 </Card>
                             )})}
                     </Container>


### PR DESCRIPTION
Abri o aplicativo ontem e me incomodei com o comunicado todo na mesma linha, então decidi corrigir. 

Quando a api pega da planilha, o texto vem com \n certinho, então o problema é no front -- para corrigir, eu substitui todos os \n por `<br>` e "pedi" para ser interpretado como HTML.

Um de vocês pode revisar, dar merge e deploy, por favor!?

